### PR TITLE
0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.3
+
+## Fixes
+
+* Whitelisted String arguments now properly display their accepted values in error messages.
+
 # 0.3.2
 
 ## Fixes

--- a/kordx-commands-runtime/src/main/kotlin/com/gitlab/kordlib/kordx/commands/argument/text/Extensions.kt
+++ b/kordx-commands-runtime/src/main/kotlin/com/gitlab/kordlib/kordx/commands/argument/text/Extensions.kt
@@ -4,6 +4,7 @@ import com.gitlab.kordlib.kordx.commands.argument.Argument
 import com.gitlab.kordlib.kordx.commands.argument.result.ArgumentResult
 import com.gitlab.kordlib.kordx.commands.argument.result.extension.FilterResult
 import com.gitlab.kordlib.kordx.commands.argument.result.extension.filter
+import java.util.*
 
 /**
  * Returns an Argument that, on top of the supplied argument, only accepts values in [whitelist].
@@ -13,15 +14,16 @@ import com.gitlab.kordlib.kordx.commands.argument.result.extension.filter
 fun <CONTEXT> Argument<String, CONTEXT>.whitelist(
         vararg whitelist: String, ignoreCase: Boolean = true
 ): Argument<String, CONTEXT> = object : Argument<String, CONTEXT> by this {
+    private val options = whitelist.contentToString()
     override suspend fun parse(text: String, fromIndex: Int, context: CONTEXT): ArgumentResult<String> {
         return this@whitelist.parse(text, fromIndex, context).filter(fromIndex) {
             when {
                 ignoreCase -> when {
                     whitelist.any { word -> word.equals(it, true) } -> FilterResult.Pass
-                    else -> FilterResult.Fail("expected one of $whitelist (not case sensitive) but got $it")
+                    else -> FilterResult.Fail("expected one of $options (not case sensitive) but got $it")
                 }
                 it in whitelist -> FilterResult.Pass
-                else -> FilterResult.Fail("expected one of $whitelist (case sensitive) but got $it")
+                else -> FilterResult.Fail("expected one of $options (case sensitive) but got $it")
             }
         }
     }


### PR DESCRIPTION
# 0.3.3

## Fixes

* Whitelisted String arguments now properly display their accepted values in error messages.
