### PR TITLE
Deprecate current auto logging methods for building bot, and create new which have optional login parameter and returns CommandProcessor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ If you have a suggestion for more targets, you can create an issue (or go to our
 ```kotlin
 @file:Autowired
 
-suspend fun main() = bot("token") {
-    configure()
+suspend fun main() {
+    bot("token", login = true) {
+        configure()
+    }
 }
 
 val prefix = prefix {

--- a/kordx-commands-processor/src/test/kotlin/ProcessFile.kt
+++ b/kordx-commands-processor/src/test/kotlin/ProcessFile.kt
@@ -52,7 +52,7 @@ val kordPrefix = prefix {
     kord { literal("+") }
 }
 
-suspend fun testReference() = bot("sample") {
+suspend fun testReference() = bot("sample", login = true) {
     configure()
 }
 

--- a/kordx-commands-runtime-kord/src/main/kotlin/com/gitlab/kordlib/kordx/commands/kord/BotBuilder.kt
+++ b/kordx-commands-runtime-kord/src/main/kotlin/com/gitlab/kordlib/kordx/commands/kord/BotBuilder.kt
@@ -1,15 +1,20 @@
 package com.gitlab.kordlib.kordx.commands.kord
 
 import com.gitlab.kordlib.core.Kord
-import com.gitlab.kordlib.kordx.commands.kord.model.processor.*
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.KordContext
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.KordContextConverter
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.KordErrorHandler
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.KordEventSource
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.KordProcessorBuilder
+import com.gitlab.kordlib.kordx.commands.kord.model.processor.eventFilter
 import com.gitlab.kordlib.kordx.commands.kord.plug.KordPlugSocket
 import com.gitlab.kordlib.kordx.commands.model.context.CommonContext
 import com.gitlab.kordlib.kordx.commands.model.processor.BaseEventHandler
 import com.gitlab.kordlib.kordx.commands.model.processor.CommandProcessor
+import com.gitlab.kordlib.kordx.commands.model.processor.EventHandler
 import com.gitlab.kordlib.kordx.commands.model.processor.ProcessorBuilder
 import mu.KotlinLogging
 import org.koin.dsl.module
-import com.gitlab.kordlib.kordx.commands.model.processor.EventHandler
 
 private val logger = KotlinLogging.logger {}
 
@@ -95,22 +100,58 @@ class BotBuilder(
         }
     }.build()
 
-
 }
 
 /**
  * Creates a bot with the given [token] as discord bot token, applying [configure] to the bot's configuration.
  * Once created, the bot will log in to the gateway and suspend until the gateway until logged out.
  */
-suspend inline fun bot(token: String, configure: KordProcessorBuilder.() -> Unit) = bot(Kord(token), configure)
+@Deprecated(
+    message = "Use bot(token, login, configure) instead.",
+    replaceWith = ReplaceWith("bot(token, login = true, configure)"),
+    level = DeprecationLevel.WARNING
+)
+suspend inline fun bot(token: String, configure: KordProcessorBuilder.() -> Unit) {
+    bot(Kord(token), login = true, configure)
+}
 
 /**
  * Creates a bot with the given [kord] instance, applying [configure] to the bot's configuration.
  * Once created, the bot will log in to the gateway and suspend until the gateway until logged out.
  */
+@Deprecated(
+    message = "Use bot(kord, login, configure) instead.",
+    replaceWith = ReplaceWith("bot(kord, login = true, configure)"),
+    level = DeprecationLevel.WARNING
+)
 suspend inline fun bot(kord: Kord, configure: KordProcessorBuilder.() -> Unit) {
-    val builder = BotBuilder(kord)
-    builder.processorBuilder.configure()
-    builder.build()
-    kord.login()
+    bot(kord, login = true, configure)
 }
+
+/**
+ * Creates a bot with the given [token] as discord bot token, applying [configure] to the bot's configuration.
+ * If [login] is true, the bot will log in to the gateway and suspend until the gateway until logged out.
+ */
+suspend inline fun bot(
+        token: String,
+        login: Boolean = false,
+        configure: KordProcessorBuilder.() -> Unit
+): Pair<Kord, CommandProcessor> {
+    val kord = Kord(token)
+    val commandProcessor = bot(kord, login, configure)
+    return Pair(kord, commandProcessor)
+}
+
+/**
+ * Creates a bot with the given [kord] instance, applying [configure] to the bot's configuration.
+ * If [login] is true, the bot will log in to the gateway and suspend until the gateway logged out.
+ */
+suspend inline fun bot(
+        kord: Kord,
+        login: Boolean,
+        configure: KordProcessorBuilder.() -> Unit
+): CommandProcessor =
+        BotBuilder(kord)
+                .apply { processorBuilder.configure() }
+                .build()
+                .also { if (login) kord.login() }

--- a/kordx-commands-runtime-kord/src/test/kotlin/commands/example/Application.kt
+++ b/kordx-commands-runtime-kord/src/test/kotlin/commands/example/Application.kt
@@ -14,10 +14,42 @@ import kapt.kotlin.generated.configure
 import kotlinx.coroutines.Dispatchers
 
 /**
- * entry method, `configure` is generated on build.
+ * Entry method, `configure` is generated on build.
  */
-suspend fun main() = bot(buildKord()) {
-    configure()
+suspend fun main() {
+    Examples.way1()
+    // Examples.way2()
+}
+
+@Suppress("UNUSED_VARIABLE")
+object Examples {
+    /**
+     * Way 1: Usage with token and default settings of [com.gitlab.kordlib.core.builder.kord.KordBuilder].
+     */
+    suspend fun way1() {
+         // If login is passed as true, there is no need of manually invoking Kord.login()
+         // and it will suspend this line until the gateway until logged out.
+        val (kord, commandProcessor) = bot("token", login = false) {
+            configure()
+        }
+        // ...
+        kord.login()
+    }
+
+    /**
+     * Way 2: Create with a [Kord] instance.
+     */
+    suspend fun way2() {
+        val kord = buildKord()
+
+        // If login is passed as true, there is no need of manually invoking Kord.login()
+        // and it will suspend this line until the gateway until logged out.
+        val commandsProcessor = bot(kord, login = false) {
+            configure()
+        }
+        // ...
+        kord.login()
+    }
 }
 
 suspend fun buildKord() = Kord(System.getenv("token")) {

--- a/kordx-commands-runtime-kord/src/test/kotlin/commands/example/ToggleCommands.kt
+++ b/kordx-commands-runtime-kord/src/test/kotlin/commands/example/ToggleCommands.kt
@@ -13,11 +13,12 @@ import com.gitlab.kordlib.kordx.commands.model.command.invoke
 import  com.gitlab.kordlib.kordx.commands.kord.module.module
 import com.gitlab.kordlib.kordx.emoji.Emojis
 import org.koin.core.get
+import org.koin.dsl.module
 
 /**
  * register our CommandSwitch dependency
  */
-val commandSwitchDependencies = org.koin.dsl.module {
+val commandSwitchDependencies = module {
     single { CommandSwitch() }
 }
 
@@ -39,7 +40,7 @@ fun Command<*>.enable() = get<CommandSwitch>().set(this, true)
 val Command<*>.isEnabled get() = get<CommandSwitch>()[this]
 
 /**
- * Cancel commands that we've disabled with the [switch].
+ * Cancel commands that we've disabled with the [Command.disable].
  */
 fun ignoreDisabledCommands() = precondition {
     command.isEnabled.also {


### PR DESCRIPTION
Fix #23